### PR TITLE
Added Maven Jar Compiling Plugin 

### DIFF
--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -158,9 +158,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -199,6 +196,24 @@
                 </executions>
             </plugin>
            
+
+            <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>3.1.1</version>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>jar</goal>
+                    </goals>
+                    <phase>package</phase>
+                    <configuration>
+                        <!--to be imported on other projects-->
+                        <classifier>jpo-geojsonconverter</classifier>
+                    </configuration>
+                </execution>
+            </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Added Maven jar Compiling Plugin. This will cause maven to build a regular maven jar file when building in addition to the springboot jar file. This allows for other projects to import the jpo-geojsonconverter if needed.