### PR TITLE
Handle @class field in JSON

### DIFF
--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/serialization/deserializers/OdeMapDataJsonDeserializer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/serialization/deserializers/OdeMapDataJsonDeserializer.java
@@ -7,6 +7,7 @@ import us.dot.its.jpo.ode.util.JsonUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.slf4j.Logger;
@@ -32,13 +33,19 @@ public class OdeMapDataJsonDeserializer implements Deserializer<OdeMapData> {
 
 			// Deserialize the metadata
 			JsonNode metadataNode = actualObj.get("metadata");
+            if (metadataNode.get("@class") != null) {
+                ((ObjectNode)metadataNode).remove("@class");
+            }
 			String metadataString = metadataNode.toString();
-			OdeMapMetadata metadataObject = (OdeMapMetadata) JsonUtils.jacksonFromJson(metadataString, OdeMapMetadata.class, true);
+			OdeMapMetadata metadataObject = (OdeMapMetadata) JsonUtils.fromJson(metadataString, OdeMapMetadata.class);
 
 			// Deserialize the payload
 			JsonNode payloadNode = actualObj.get("payload");
+            if (payloadNode.get("@class") != null) {
+                ((ObjectNode)payloadNode).remove("@class");
+            }
 			String payloadString = payloadNode.toString();
-			OdeMapPayload mapPayload = (OdeMapPayload) JsonUtils.jacksonFromJson(payloadString, OdeMapPayload.class, true);
+			OdeMapPayload mapPayload = (OdeMapPayload) JsonUtils.fromJson(payloadString, OdeMapPayload.class);
 
             OdeMapData returnData = new OdeMapData(metadataObject, mapPayload);
             return returnData;

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/serialization/deserializers/OdeSpatDataJsonDeserializer.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/serialization/deserializers/OdeSpatDataJsonDeserializer.java
@@ -7,6 +7,7 @@ import us.dot.its.jpo.ode.util.JsonUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.apache.kafka.common.serialization.Deserializer;
 import org.slf4j.Logger;
@@ -33,13 +34,19 @@ public class OdeSpatDataJsonDeserializer implements Deserializer<OdeSpatData> {
 
             // Deserialize the metadata
             JsonNode metadataNode = actualObj.get("metadata");
+            if (metadataNode.get("@class") != null) {
+                ((ObjectNode)metadataNode).remove("@class");
+            }
             String metadataString = metadataNode.toString();
-            OdeSpatMetadata metadataObject = (OdeSpatMetadata) JsonUtils.jacksonFromJson(metadataString, OdeSpatMetadata.class, true);
+            OdeSpatMetadata metadataObject = (OdeSpatMetadata) JsonUtils.fromJson(metadataString, OdeSpatMetadata.class);
 
             // Deserialize the payload
             JsonNode payloadNode = actualObj.get("payload");
+            if (payloadNode.get("@class") != null) {
+                ((ObjectNode)payloadNode).remove("@class");
+            }
             String payloadString = payloadNode.toString();
-            OdeSpatPayload mapPayload = (OdeSpatPayload) JsonUtils.jacksonFromJson(payloadString, OdeSpatPayload.class, true);
+            OdeSpatPayload mapPayload = (OdeSpatPayload) JsonUtils.fromJson(payloadString, OdeSpatPayload.class);
 
             OdeSpatData returnData = new OdeSpatData(metadataObject, mapPayload);
             return returnData;

--- a/jpo-geojsonconverter/src/main/resources/logback.xml
+++ b/jpo-geojsonconverter/src/main/resources/logback.xml
@@ -9,10 +9,9 @@
 	</appender>
 
 	<logger name="us.dot.its.jpo.geojsonconverter.eventlog.EventLogger" level="ERROR" />
-	
-	<logger name="org.springframework.web" level="INFO" />
-	<logger name="us.dot.its.jpo.geojsonconverter" level="DEBUG" />
+	<logger name="org.springframework.web" level="WARN" />
 	<logger name="org.springframework.test" level="DEBUG"/>
+	<logger name="us.dot.its.jpo.geojsonconverter" level="INFO" />
 
 	<root level="WARN">
 		<appender-ref ref="STDOUT" />


### PR DESCRIPTION
- Small addition for handling the @class field. 
  - The previous solution seems to not fully support @class so this update simply removes the field from the JsonNode if it exists.
  - Reverted the deserialization function from jacksonFromJson back to fromJson since the JsonNodes can be treated as not having the @class field
- Tighten the logging rules for the repository. If we need to loosen them for debugging purposes this can be done locally.