### PR TITLE
Trim ProcessedMapWKT Output

### DIFF
--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/map/MapProcessedWKTConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/map/MapProcessedWKTConverter.java
@@ -23,7 +23,15 @@ public class MapProcessedWKTConverter implements Transformer<RsuIntersectionKey,
      */
     @Override
     public KeyValue<RsuIntersectionKey, ProcessedMap<String>> transform(RsuIntersectionKey key, ProcessedMap<LineString> geoJSONMap) {
-        return KeyValue.pair(key, WKTHandler.processedMapGeoJSON2WKT(geoJSONMap));
+        ProcessedMap<String> wktProcessedMap = WKTHandler.processedMapGeoJSON2WKT(geoJSONMap);
+
+        // Remove parts of the ProcessedMap that are not needed since WKT is not used by the Conflict Monitor
+        wktProcessedMap.getProperties().setValidationMessages(null);
+        for (int i = 0; i < wktProcessedMap.getMapFeatureCollection().getFeatures().length; i++) {
+            wktProcessedMap.getMapFeatureCollection().getFeatures()[i].getProperties().setNodes(null);
+        }
+
+        return KeyValue.pair(key, wktProcessedMap);
     }
 
     @Override


### PR DESCRIPTION
This is a small fix for trimming the Conflict Monitor related output from the ProcessedMapWKT feed since this feed is not used by the Conflict Monitor. This was a requested change by CDOT to cut down on unnecessary message size.