### PR TITLE
Log Level Review

### DIFF
--- a/docker-compose-standalone.yml
+++ b/docker-compose-standalone.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  geojsonconverter:
+    build: .
+    image: jpo_geojsonconverter:latest
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      geometry.output.mode: ${GEOMETRY_OUTPUT_MODE}
+      spring.kafka.bootstrap-servers: ${DOCKER_HOST_IP}:9092
+    logging: 
+      options:
+        max-size: "10m"
+        max-file: "5"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,22 @@
 version: '3'
 services:
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: ${DOCKER_HOST_IP}
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_CREATE_TOPICS: "topic.ProcessedSpat:1:1,topic.ProcessedMap:1:1,topic.ProcessedMapWKT:1:1"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - zookeeper
+
   geojsonconverter:
     build: .
     image: jpo_geojsonconverter:latest
@@ -11,3 +28,5 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+    depends_on:
+      - kafka

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/KafkaConfiguration.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/KafkaConfiguration.java
@@ -33,7 +33,7 @@ public class KafkaConfiguration {
     @Profile("!test")
     @Bean(name = "createKafkaTopics")
     public KafkaAdmin.NewTopics createKafkaTopics() {
-        logger.info("createTopic");
+        logger.debug("'createKafkaTopics()' method called");
         List<NewTopic> newTopics = new ArrayList<>();
         
         if(!properties.getConfluentCloudStatus()){
@@ -95,7 +95,7 @@ public class KafkaConfiguration {
 
 
             } catch (Exception e) {
-                logger.error("Exception in createKafkaTopics", e);
+                logger.error("Exception in createKafkaTopics() method: ", e);
                 throw e;
             }
         }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/JsonConverterServiceController.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/JsonConverterServiceController.java
@@ -29,7 +29,7 @@ public class JsonConverterServiceController {
         super();
 
         try {
-            logger.info("Starting {}", this.getClass().getSimpleName());
+            logger.debug("Starting {}", this.getClass().getSimpleName());
             
             // MAP
             logger.info("Creating the Processed MAP Kafka-Streams topology");
@@ -69,7 +69,7 @@ public class JsonConverterServiceController {
 
             logger.info("All geoJSON conversion services started!");
         } catch (Exception e) {
-            logger.error("Encountered issue with creating topologies", e);
+            logger.error("Encountered error with creating topologies: ", e);
         }
     }
 }


### PR DESCRIPTION
## Changes
The log levels being used in each log statement have been reviewed and some adjustments have been made.

## Testing
The application compiled & spun up successfully via docker-compose.

### Kafka Disconnection
During my testing the geojsonconverter would lose connection to the kafka cluster shortly after spinning up. Nothing that was changed should affect the actual functionality of the application, so I don't think this is indicative of a problem caused by these changes.

## Additional Changes
- The content of some error messages has been modified.
- The zookeeper & kafka services have been added to `docker-compose.yml` to make local testing easier.
- The `docker-compose-standalone.yml` file has been added for developers that want to spin up the geojsonconverter on its own.