### PR TITLE
Remove MongoDB dependency

### DIFF
--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -154,10 +154,6 @@
             <artifactId>jts-core</artifactId>
             <version>1.19.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <finalName>${project.artifactId}</finalName>

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/map/ProcessedMap.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/map/ProcessedMap.java
@@ -9,12 +9,12 @@ import us.dot.its.jpo.geojsonconverter.pojos.geojson.connectinglanes.ConnectingL
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.mongodb.core.mapping.Document;
+
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-@Document("ProcessedMap")
+
 @JsonPropertyOrder({"mapFeatureCollection", "connectingLanesFeatureCollection", "properties"})
 public class ProcessedMap<TGeometry> {
     private static Logger logger = LoggerFactory.getLogger(MapProperties.class);

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/spat/ProcessedSpat.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/spat/ProcessedSpat.java
@@ -14,10 +14,9 @@ import us.dot.its.jpo.geojsonconverter.pojos.ProcessedValidationMessage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.data.mongodb.core.mapping.Document;
+
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Document("ProcessedSpat")
 public class ProcessedSpat {
     private static Logger logger = LoggerFactory.getLogger(ProcessedSpat.class);
 


### PR DESCRIPTION
Removes the `@Document` annotations from `ProcessedMap` and `ProcessedSpat`, and remove the Spring MongoDB dependency from the POM.

The reason for doing this it that the MongoDB dependency is going to be removed from the Conflict Monitor in a related PR. [LINK TO BE INSERTED HERE].  This will prevent pulling the Spring Mongo dependency into the CM which causes issues there when the Mongo DB is not configured in Java code.