### PR TITLE
Fixed Issue with generating UTC timestamps when Hour rolls over

### DIFF
--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverter.java
@@ -217,18 +217,26 @@ public class SpatProcessedJsonConverter implements Transformer<Void, Deserialize
             if (timeMark != null){
                 long millis = Long.valueOf(timeMark)*100;
                 ZonedDateTime date = originTimestamp;
+                if(timeMark == 36011 || timeMark == 36001){
 
-                // If we are within 10 minutes of the next hour, and the timeMark is a small number, it probably means that the time is rolling over.
-                // In this case, add an hour to the UTC timestamp so that it appears in the future instead of in the past.s
-                if(originTimestamp.getMinute() > 50 && timeMark < 6000){
-                    date = date.plusHours(1);
+                    // Return UTC time zero if the Zoned Date time is marked as unknown, UTC time zero chosen so that a null value can represent an empty field in the SPaT. But 36011, can represent an intentionally unidentified field.
+                    return ZonedDateTime.ofInstant(Instant.ofEpochMilli(0), ZoneId.of("UTC"));
+                    
+                }else{
+                    // If we are within 10 minutes of the next hour, and the timeMark is a small number, it probably means that the time is rolling over.
+                    // In this case, add an hour to the UTC timestamp so that it appears in the future instead of in the past.s
+                    if(originTimestamp.getMinute() > 50 && timeMark < 6000){
+                        date = date.plusHours(1);
+                    }
+
+                    date = date.withMinute(0);
+                    date = date.withSecond(0);
+                    date = date.withNano(0);
+                    date = date.plus(millis, ChronoUnit.MILLIS);
+                    return date;
                 }
 
-                date = date.withMinute(0);
-                date = date.withSecond(0);
-                date = date.withNano(0);
-                date = date.plus(millis, ChronoUnit.MILLIS);
-                return date;
+                
             } else {
                 return null;
             }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverter.java
@@ -217,6 +217,13 @@ public class SpatProcessedJsonConverter implements Transformer<Void, Deserialize
             if (timeMark != null){
                 long millis = Long.valueOf(timeMark)*100;
                 ZonedDateTime date = originTimestamp;
+
+                // If we are within 10 minutes of the next hour, and the timeMark is a small number, it probably means that the time is rolling over.
+                // In this case, add an hour to the UTC timestamp so that it appears in the future instead of in the past.s
+                if(originTimestamp.getMinute() > 50 && timeMark < 6000){
+                    date = date.plusHours(1);
+                }
+
                 date = date.withMinute(0);
                 date = date.withSecond(0);
                 date = date.withNano(0);


### PR DESCRIPTION
The generateOffsetUTCTimestamp function will incorrectly generate a UTC timestamp for a corresponding time mark when the time in the SPaT message is near the hour mark. This change checks to see if the SPaT is close to the hour (10 minutes) and the timeMark is suitably small that it is likely in the next hour (first 10 minutes). If so, the time is shifted so that the UTC time representing the hour is in the next hour instead of the current hour. This ensures that the timeChangeDetailsEvents in the SPaT message are in the future and not in the past. 