### PR TITLE
Partition by intersection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
           cd jpo-ode
           mvn install -DskipTests
           cd ../jpo-geojsonconverter
-          mvn -e -X clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar -Dsonar.projectKey=usdot-jpo-ode_jpo-geojsonconverter -Dsonar.projectName=jpo-geojsonconverter -Dsonar.organization=usdot-jpo-ode-1 -Dsonar.host.url=https://sonarcloud.io -Dsonar.branch.name=$GITHUB_REF_NAME
+          mvn -e -X clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar -Dsonar.projectKey=usdot-jpo-ode_jpo-geojsonconverter -Dsonar.projectName=jpo-geojsonconverter -Dsonar.organization=usdot-jpo-ode -Dsonar.host.url=https://sonarcloud.io -Dsonar.branch.name=$GITHUB_REF_NAME

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/map/MapProcessedJsonConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/map/MapProcessedJsonConverter.java
@@ -63,7 +63,8 @@ public class MapProcessedJsonConverter implements Transformer<Void, Deserialized
 
                 var key = new RsuIntersectionKey();
                 key.setRsuId(mapMetadata.getOriginIp());
-                key.setIntersectionId(intersection.getId().getId());
+                key.setIntersectionReferenceID(intersection.getId());
+
                 logger.debug("Successfully created MAP GeoJSON for {}", key);
                 return KeyValue.pair(key, processedMapObject);
             } else {

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/map/MapTopology.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/map/MapTopology.java
@@ -10,7 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.kafka.streams.kstream.KStream;
 
-import us.dot.its.jpo.geojsonconverter.partitioner.RsuIdPartitioner;
+import us.dot.its.jpo.geojsonconverter.partitioner.IntersectionIdPartitioner;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
 import us.dot.its.jpo.geojsonconverter.pojos.GeometryOutputMode;
 import us.dot.its.jpo.geojsonconverter.pojos.geojson.LineString;
@@ -81,7 +81,7 @@ public class MapTopology {
             Produced.with(
                 JsonSerdes.RsuIntersectionKey(), // Key is now an RsuIntersectionKey object
                 JsonSerdes.ProcessedMapGeoJson(),      // Value serializer for MAP GeoJSON
-                new RsuIdPartitioner<RsuIntersectionKey, ProcessedMap<LineString>>())  // Partition by RSU ID
+                new IntersectionIdPartitioner<RsuIntersectionKey, ProcessedMap<LineString>>())  // Partition by Intersection ID
             );
         
         if (gom == GeometryOutputMode.WKT) {
@@ -101,7 +101,7 @@ public class MapTopology {
                 Produced.with(
                     JsonSerdes.RsuIntersectionKey(), // Key is still an RsuIntersectionKey object
                     JsonSerdes.ProcessedMapWKT(),      // Value serializer for MAP WKT
-                    new RsuIdPartitioner<RsuIntersectionKey, ProcessedMap<String>>())  // Partition by RSU ID
+                    new IntersectionIdPartitioner<RsuIntersectionKey, ProcessedMap<String>>())  // Partition by Intersection ID
                 );
         }
         

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverter.java
@@ -39,7 +39,7 @@ public class SpatProcessedJsonConverter implements Transformer<Void, Deserialize
      * Transform an ODE SPaT POJO to Processed SPaT POJO.
      * 
      * @param rawKey   - Void type because ODE topics have no specified key
-     * @param rawValue - The raw POJO
+     * @param rawSpat - The raw POJO
      * @return A key value pair: the key an {@link RsuIntersectionKey} containing the RSU IP address and Intersection ID
      *  and the value is the GeoJSON FeatureCollection POJO
      */
@@ -59,7 +59,7 @@ public class SpatProcessedJsonConverter implements Transformer<Void, Deserialize
 
                 var key = new RsuIntersectionKey();
                 key.setRsuId(spatMetadata.getOriginIp());
-                key.setIntersectionId(intersectionState.getId().getId());
+                key.setIntersectionReferenceID(intersectionState.getId());
                 return KeyValue.pair(key, processedSpat);
             } else {
                 ProcessedSpat processedSpat = createFailureProcessedSpat(rawSpat.getValidatorResults(), rawSpat.getFailedMessage());

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatTopology.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatTopology.java
@@ -10,7 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.kafka.streams.kstream.KStream;
 
-import us.dot.its.jpo.geojsonconverter.partitioner.RsuIdPartitioner;
+import us.dot.its.jpo.geojsonconverter.partitioner.IntersectionIdPartitioner;
 import us.dot.its.jpo.geojsonconverter.partitioner.RsuIntersectionKey;
 import us.dot.its.jpo.geojsonconverter.pojos.spat.DeserializedRawSpat;
 import us.dot.its.jpo.geojsonconverter.pojos.spat.ProcessedSpat;
@@ -77,7 +77,7 @@ public class SpatTopology {
             Produced.with(
                 JsonSerdes.RsuIntersectionKey(),
                 JsonSerdes.ProcessedSpat(), 
-                new RsuIdPartitioner<RsuIntersectionKey, ProcessedSpat>())  // Partition by RSU ID
+                new IntersectionIdPartitioner<RsuIntersectionKey, ProcessedSpat>())  // Partition by RSU ID
         );
         
         return builder.build();

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/IntersectionIdPartitioner.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/IntersectionIdPartitioner.java
@@ -7,30 +7,32 @@ import us.dot.its.jpo.geojsonconverter.serialization.serializers.JsonSerializer;
 import java.nio.ByteBuffer;
 
 /**
- * Partitioner that partitions based only on Intersection ID for
- * objects that implement the {@link IntersectionKey} class.
+ * Partitioner that partitions based only on Intersection ID for objects that implement the {@link IntersectionKey} class.
  *
  * <p>Partitioning ignores the region, so that items with or without a region defined will be on the same partition.</p>
  *
- * <p>Objects that don't implement the {@link IntersectionKey} are partitioned on the entire serialized key, the same as the kafka default behavior.</p>
+ * <p>Objects that don't implement the {@link IntersectionKey} interface are partitioned on the hash of the entire
+ * serialized key, the same as the kafka default behavior.</p>
  */
 public class IntersectionIdPartitioner<K, V> implements StreamPartitioner<K, V> {
 
     @Override
     public Integer partition(String topic, K key, V value, int numPartitions) {
-        byte[] partitionBytes;
+
 
         if (key instanceof IntersectionKey) {
             var intersectionKey = (IntersectionKey)key;
             int intersectionId = intersectionKey.getIntersectionId();
-            partitionBytes = ByteBuffer.allocate(Integer.SIZE/8).putInt(intersectionId).array();
+            return intersectionId % numPartitions;
         } else {
+            byte[] partitionBytes;
             try (var serializer = new JsonSerializer<K>()) {
                 partitionBytes = serializer.serialize(topic, key);
             }
+            return Utils.toPositive(Utils.murmur2(partitionBytes)) % numPartitions;
         }
 
-        return Utils.toPositive(Utils.murmur2(partitionBytes)) % numPartitions;
+
     }
 
 }

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/IntersectionIdPartitioner.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/IntersectionIdPartitioner.java
@@ -1,0 +1,36 @@
+package us.dot.its.jpo.geojsonconverter.partitioner;
+
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import us.dot.its.jpo.geojsonconverter.serialization.serializers.JsonSerializer;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Partitioner that partitions based only on Intersection ID for
+ * objects that implement the {@link IntersectionKey} class.
+ *
+ * <p>Partitioning ignores the region, so that items with or without a region defined will be on the same partition.</p>
+ *
+ * <p>Objects that don't implement the {@link IntersectionKey} are partitioned on the entire serialized key, the same as the kafka default behavior.</p>
+ */
+public class IntersectionIdPartitioner<K, V> implements StreamPartitioner<K, V> {
+
+    @Override
+    public Integer partition(String topic, K key, V value, int numPartitions) {
+        byte[] partitionBytes;
+
+        if (key instanceof IntersectionKey) {
+            var intersectionKey = (IntersectionKey)key;
+            int intersectionId = intersectionKey.getIntersectionId();
+            partitionBytes = ByteBuffer.allocate(Integer.SIZE/8).putInt(intersectionId).array();
+        } else {
+            try (var serializer = new JsonSerializer<K>()) {
+                partitionBytes = serializer.serialize(topic, key);
+            }
+        }
+
+        return Utils.toPositive(Utils.murmur2(partitionBytes)) % numPartitions;
+    }
+
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/IntersectionKey.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/IntersectionKey.java
@@ -1,0 +1,17 @@
+package us.dot.its.jpo.geojsonconverter.partitioner;
+
+/**
+ * Interface for keys that act as an intersection based partitioning scheme.
+ */
+public interface IntersectionKey {
+
+    /**
+     * @return The J2735 Intersection ID
+     */
+    int getIntersectionId();
+
+    /**
+     * @return The J2735 Region (Road Regulator ID)
+     */
+    int getRegion();
+}

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIdPartitioner.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIdPartitioner.java
@@ -10,7 +10,7 @@ public class RsuIdPartitioner<K, V> implements StreamPartitioner<K, V> {
 
 
     @Override
-    public Integer partition(String topic, K key, V vlaue, int numPartitions) {
+    public Integer partition(String topic, K key, V value, int numPartitions) {
         
         byte[] partitionBytes;
         

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKey.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKey.java
@@ -19,6 +19,13 @@ public class RsuIntersectionKey implements RsuIdKey, IntersectionKey {
     public RsuIntersectionKey(String rsuId, int intersectionId) {
         this.rsuId = rsuId;
         this.intersectionId = intersectionId;
+        this.region = 0;
+    }
+
+    public RsuIntersectionKey(String rsuId, int intersectionId, int region) {
+        this.rsuId = rsuId;
+        this.intersectionId = intersectionId;
+        this.region = region;
     }
 
     @Override

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKey.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKey.java
@@ -1,15 +1,18 @@
 package us.dot.its.jpo.geojsonconverter.partitioner;
 
+import us.dot.its.jpo.ode.plugin.j2735.J2735IntersectionReferenceID;
+
 import java.util.Objects;
 
 
 /**
  * Kafka key for topics with an RSU ID and Intersection ID.
  */
-public class RsuIntersectionKey implements RsuIdKey {
+public class RsuIntersectionKey implements RsuIdKey, IntersectionKey {
     
     private String rsuId;
     private int intersectionId;
+    private int region;
 
     public RsuIntersectionKey() {}
  
@@ -28,6 +31,7 @@ public class RsuIntersectionKey implements RsuIdKey {
         this.rsuId = rsuId;
     }
 
+    @Override
     public int getIntersectionId() {
         return this.intersectionId;
     }
@@ -35,8 +39,37 @@ public class RsuIntersectionKey implements RsuIdKey {
     public void setIntersectionId(int intersectionId) {
         this.intersectionId = intersectionId;
     }
+    public void setIntersectionId(Integer intersectionId) {
+        if (intersectionId != null) {
+            setIntersectionId(intersectionId.intValue());
+        }
+    }
 
- 
+    /**
+     * Sets both intersection ID and region with null checks
+     * @param referenceID J2735IntersectionReferenceID
+     */
+    public void setIntersectionReferenceID(J2735IntersectionReferenceID referenceID) {
+        if (referenceID != null) {
+            setIntersectionId(referenceID.getId());
+            setRegion(referenceID.getRegion());
+        }
+    }
+
+    @Override
+    public int getRegion() {
+        return region;
+    }
+    public void setRegion(int region) {
+        this.region = region;
+    }
+    public void setRegion(Integer region) {
+        if (region != null) {
+            setRegion(region.intValue());
+        }
+    }
+
+
     @Override
     public boolean equals(Object o) {
         if (o == this)
@@ -45,12 +78,13 @@ public class RsuIntersectionKey implements RsuIdKey {
             return false;
         }
         RsuIntersectionKey rsuIntersectionKey = (RsuIntersectionKey) o;
-        return Objects.equals(rsuId, rsuIntersectionKey.rsuId) && intersectionId == rsuIntersectionKey.intersectionId;
+        return Objects.equals(rsuId, rsuIntersectionKey.rsuId) && intersectionId == rsuIntersectionKey.intersectionId
+                && region == rsuIntersectionKey.region;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(rsuId, intersectionId);
+        return Objects.hash(rsuId, intersectionId, region);
     }
     
 
@@ -61,6 +95,7 @@ public class RsuIntersectionKey implements RsuIdKey {
         return "{" +
             " rsuId='" + getRsuId() + "'" +
             ", intersectionId='" + getIntersectionId() + "'" +
+            ", region='" + getRegion() + "'" +
             "}";
     }
     

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/partitioner/IntersectionIdPartitionerTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/partitioner/IntersectionIdPartitionerTest.java
@@ -1,0 +1,84 @@
+package us.dot.its.jpo.geojsonconverter.partitioner;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+
+public class IntersectionIdPartitionerTest {
+
+    @Test
+    public void testPartition_IntersectionKey() {
+
+        final String topic = "topic";
+        final String ip1 = "1.1.1.1";
+        final String ip2 = "2.2.2.2";
+        final int intersection1 = 100000;
+        final int intersection2 = 111111;
+        final int region1 = 10;
+        final int region2 = 22;
+
+        var key111 = new RsuIntersectionKey(ip1, intersection1, region1);
+        var key111_same = new RsuIntersectionKey(ip1, intersection1, region1);
+        var key112 = new RsuIntersectionKey(ip1, intersection1, region2);
+        var key121 = new RsuIntersectionKey(ip1, intersection2, region1);
+        var key122 = new RsuIntersectionKey(ip1, intersection2, region2);
+        var key211 = new RsuIntersectionKey(ip2, intersection1, region1);
+        var key212 = new RsuIntersectionKey(ip2, intersection1, region2);
+        var key221 = new RsuIntersectionKey(ip2, intersection2, region1);
+        var key222 = new RsuIntersectionKey(ip2, intersection2, region2);
+
+        final Object value = new Object();
+
+        // Minimize possibility of collisions
+        final int numPartitions = Integer.MAX_VALUE;
+
+        var partitioner = new IntersectionIdPartitioner<RsuIntersectionKey, Object>();
+
+        int partition111 = partitioner.partition(topic, key111, value, numPartitions);
+        int partition111_same = partitioner.partition(topic, key111_same, value, numPartitions);
+        int partition112 = partitioner.partition(topic, key112, value, numPartitions);
+        int partition121 = partitioner.partition(topic, key121, value, numPartitions);
+        int partition122 = partitioner.partition(topic, key122, value, numPartitions);
+        int partition211 = partitioner.partition(topic, key211, value, numPartitions);
+        int partition212 = partitioner.partition(topic, key212, value, numPartitions);
+        int partition221 = partitioner.partition(topic, key221, value, numPartitions);
+        int partition222 = partitioner.partition(topic, key222, value, numPartitions);
+
+        final String equalMsg = "Keys with the same intersectionID should have the same partition, regardless of rsuIP and region.";
+        assertEquals(equalMsg, partition111, partition111_same);
+        assertEquals(equalMsg, partition111, partition112);
+        assertEquals(equalMsg, partition111, partition211);
+        assertEquals(equalMsg, partition111, partition212);
+
+        final String notEqualMsg = "Keys with different intersectionIDs are unlikely to have the same partition number";
+        assertNotEquals(notEqualMsg, partition111, partition121);
+        assertNotEquals(notEqualMsg, partition111, partition122);
+        assertNotEquals(notEqualMsg, partition111, partition221);
+        assertNotEquals(notEqualMsg, partition111, partition222);
+
+    }
+
+    @Test
+    public void testPartition_String() {
+
+        // Test that the custom partition function still behaves normally if the key is a string
+
+        final String topic = "topic";
+        final String key = "AAA";
+        final String sameKey = "AAA";
+        final String differentKey = "BBB";
+        final Object obj = new Object();
+        final int numPartitions = Integer.MAX_VALUE;
+
+        var partitioner = new IntersectionIdPartitioner<String, Object>();
+
+        int partitionKey = partitioner.partition(topic, key, obj, numPartitions);
+        int partitionSame = partitioner.partition(topic, sameKey, obj, numPartitions);
+        int partitionDifferent = partitioner.partition(topic, differentKey, obj, numPartitions);
+
+        assertEquals("Same keys", partitionKey, partitionSame);
+        assertNotEquals("Different keys", partitionKey, partitionDifferent);
+    }
+}

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIdPartitionerTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIdPartitionerTest.java
@@ -27,7 +27,7 @@ public class RsuIdPartitionerTest {
 
         final Object obj = new Object();
 
-        // Minimimize possibility of collisions
+        // Minimize possibility of collisions
         final int numPartitions = Integer.MAX_VALUE;
 
         var partitioner = new RsuIdPartitioner<RsuIntersectionKey, Object>();

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKeyTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKeyTest.java
@@ -8,29 +8,36 @@ import static org.hamcrest.Matchers.*;
 
 
 import org.junit.Test;
+import us.dot.its.jpo.ode.plugin.j2735.J2735IntersectionReferenceID;
 
 
 public class RsuIntersectionKeyTest {
 
     final static String ipAddress = "127.0.0.1";
-    final static int intersectionId = 10001; 
+    final static int intersectionId = 10001;
+    final static int region = 10;
     
     @Test
     public void testEquality() {        
         
         var key = new RsuIntersectionKey();
         key.setRsuId(ipAddress);
-        key.setIntersectionId(intersectionId);
+        var intersectionRegion = new J2735IntersectionReferenceID();
+        intersectionRegion.setId(intersectionId);
+        intersectionRegion.setRegion(region);
+        key.setIntersectionReferenceID(intersectionRegion);
 
-        var keyValue = new RsuIntersectionKey(ipAddress, intersectionId);
+        var keyValue = new RsuIntersectionKey(ipAddress, intersectionId, region);
         var keyRef = key;
         Object otherObject = new Object();
         var otherValue1 = new RsuIntersectionKey(ipAddress, 99);
         var otherValue2 = new RsuIntersectionKey("0.0.0.0", 99);
+        var otherValue3 = new RsuIntersectionKey(ipAddress, intersectionId, 99);
 
         assertTrue("Value equality", key.equals(keyValue));
         assertFalse("Value inequality branch 1", key.equals(otherValue1));
         assertFalse("Value inequality branch 2", key.equals(otherValue2));
+        assertFalse("Value inequality branch 3", key.equals(otherValue3));
         assertTrue("Reference equality", key.equals(keyRef));
         assertFalse("Reference inequality", key.equals(otherObject));
         assertEquals("Hash code values equal", key.hashCode(), keyValue.hashCode());
@@ -38,6 +45,7 @@ public class RsuIntersectionKeyTest {
         // Getter coverage
         assertEquals("getRsuId", key.getRsuId(), keyValue.getRsuId());
         assertEquals("getIntersectionId", key.getIntersectionId(), keyValue.getIntersectionId());
+        assertEquals("getRegion", key.getRegion(), keyValue.getRegion());
 
     }
 


### PR DESCRIPTION
Update to partition the ProcessedMap and ProcessedSpat topics by Intersection ID instead of by RSU IP address.  See the issue: [Issue #36 Partition outputs by Intersection ID](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/issues/36) for the rationale for changing this.

Creates a new interface, `IntersectionKey`, and Streams partitioner, `IntersectionIdPartitioner`, that partitions records whose keys implement the interface by Intersection ID.   The `IntersectionKey` interface includes the region (Road Regulator ID) for downstream use, but only the intersection ID is used for partitioning, so that records with or without a region will be on the same partition.

Adds a unit test for the new partitioner.

Includes the Sonar org name update from [PR #34 Update sonar organization to usdot-jpo-ode](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/pull/34) 