### PR TITLE
Use -1 to indicate missing intersection id/region

### DIFF
--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKey.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKey.java
@@ -19,7 +19,7 @@ public class RsuIntersectionKey implements RsuIdKey, IntersectionKey {
     public RsuIntersectionKey(String rsuId, int intersectionId) {
         this.rsuId = rsuId;
         this.intersectionId = intersectionId;
-        this.region = 0;
+        this.region = -1;
     }
 
     public RsuIntersectionKey(String rsuId, int intersectionId, int region) {
@@ -49,6 +49,8 @@ public class RsuIntersectionKey implements RsuIdKey, IntersectionKey {
     public void setIntersectionId(Integer intersectionId) {
         if (intersectionId != null) {
             setIntersectionId(intersectionId.intValue());
+        } else {
+            setIntersectionId(-1);
         }
     }
 

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKey.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/partitioner/RsuIntersectionKey.java
@@ -73,6 +73,9 @@ public class RsuIntersectionKey implements RsuIdKey, IntersectionKey {
     public void setRegion(Integer region) {
         if (region != null) {
             setRegion(region.intValue());
+        } else {
+            // Use -1 to indicate region is missing
+            setRegion(-1);
         }
     }
 


### PR DESCRIPTION
Minor tweak to the `RsuIntersectionKey` class so that it uses -1 instead of 0 to indicate missing region or Intersection ID, since 0 is reserved for testing according to J2735.