### PR TITLE
Updated ODE reference version in pom.xml to 2.0.0-SNAPSHOT

### DIFF
--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -126,12 +126,12 @@
         <dependency>
             <groupId>usdot.jpo.ode</groupId>
             <artifactId>jpo-ode-core</artifactId>
-            <version>1.6.0-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>usdot.jpo.ode</groupId>
             <artifactId>jpo-ode-plugins</artifactId>
-            <version>1.6.0-SNAPSHOT</version>
+            <version>2.0.0-SNAPSHOT</version>
         </dependency>
 
         <!-- Other Dependencies -->


### PR DESCRIPTION
## Problem
The version of the ODE for the upcoming release has been updated in https://github.com/usdot-jpo-ode/jpo-ode/pull/537.

## Solution
The pom.xml has been updated to correctly reference the upcoming release version.