### PR TITLE
Add schema version to ProcessedMap and ProcessedSpat

### DIFF
--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/map/MapProcessedJsonConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/map/MapProcessedJsonConverter.java
@@ -53,6 +53,10 @@ public class MapProcessedJsonConverter implements Transformer<Void, Deserialized
                 J2735IntersectionGeometry intersection = mapPayload.getMap().getIntersections().getIntersections().get(0);
 
                 MapSharedProperties sharedProps = createProperties(mapPayload, mapMetadata, intersection, rawValue.getValidatorResults());
+
+                // Set the schema version
+                sharedProps.setSchemaVersion(1);
+
                 MapFeatureCollection<LineString> mapFeatureCollection = createFeatureCollection(intersection);
                 ConnectingLanesFeatureCollection<LineString> connectingLanesFeatureCollection = createConnectingLanesFeatureCollection(mapMetadata, intersection);
 

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverter.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/converter/spat/SpatProcessedJsonConverter.java
@@ -57,6 +57,9 @@ public class SpatProcessedJsonConverter implements Transformer<Void, Deserialize
 
                 ProcessedSpat processedSpat = createProcessedSpat(intersectionState, spatMetadata, rawSpat.getValidatorResults());
 
+                // Set the schema version
+                processedSpat.setSchemaVersion(1);
+
                 var key = new RsuIntersectionKey();
                 key.setRsuId(spatMetadata.getOriginIp());
                 key.setIntersectionReferenceID(intersectionState.getId());

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/map/MapSharedProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/map/MapSharedProperties.java
@@ -23,7 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class MapSharedProperties {
     private static Logger logger = LoggerFactory.getLogger(MapSharedProperties.class);
 
-    private final Integer schemaVersion = 1;
+    // Default schemaVersion is -1 for older messages that lack a schemaVersion value
+    private int schemaVersion = -1;
     private String messageType = "MAP";
     private ZonedDateTime odeReceivedAt;
     private String originIp;
@@ -40,8 +41,12 @@ public class MapSharedProperties {
     private MapSource mapSource;
     private ZonedDateTime timeStamp;
 
-    public Integer getSchemaVersion() {
+    public int getSchemaVersion() {
         return schemaVersion;
+    }
+
+    public void setSchemaVersion(int schemaVersion) {
+        this.schemaVersion = schemaVersion;
     }
 
     public void setMessageType(String messageType) {

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/map/MapSharedProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/map/MapSharedProperties.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class MapSharedProperties {
     private static Logger logger = LoggerFactory.getLogger(MapSharedProperties.class);
 
+    private final Integer schemaVersion = 1;
     private String messageType = "MAP";
     private ZonedDateTime odeReceivedAt;
     private String originIp;
@@ -38,6 +39,10 @@ public class MapSharedProperties {
     private List<J2735RegulatorySpeedLimit> speedLimits;
     private MapSource mapSource;
     private ZonedDateTime timeStamp;
+
+    public Integer getSchemaVersion() {
+        return schemaVersion;
+    }
 
     public void setMessageType(String messageType) {
         this.messageType = messageType;

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/spat/ProcessedSpat.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/spat/ProcessedSpat.java
@@ -20,7 +20,8 @@ import org.slf4j.LoggerFactory;
 public class ProcessedSpat {
     private static Logger logger = LoggerFactory.getLogger(ProcessedSpat.class);
 
-    private final Integer schemaVersion = 1;
+    // Default schemaVersion is -1 for older messages that lack a schemaVersion value
+    private int schemaVersion = -1;
     private String messageType = "SPAT";
     private String odeReceivedAt;
     private String originIp;
@@ -35,8 +36,12 @@ public class ProcessedSpat {
     private List<Integer> enabledLanes = new ArrayList<>();
     private List<MovementState> states = null;
 
-    public Integer getSchemaVersion() {
+    public int getSchemaVersion() {
         return schemaVersion;
+    }
+
+    public void setSchemaVersion(int schemaVersion) {
+        this.schemaVersion = schemaVersion;
     }
 
     public String getMessageType() {

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/spat/ProcessedSpat.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/pojos/spat/ProcessedSpat.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 public class ProcessedSpat {
     private static Logger logger = LoggerFactory.getLogger(ProcessedSpat.class);
 
+    private final Integer schemaVersion = 1;
     private String messageType = "SPAT";
     private String odeReceivedAt;
     private String originIp;
@@ -33,6 +34,10 @@ public class ProcessedSpat {
     private ZonedDateTime utcTimeStamp;
     private List<Integer> enabledLanes = new ArrayList<>();
     private List<MovementState> states = null;
+
+    public Integer getSchemaVersion() {
+        return schemaVersion;
+    }
 
     public String getMessageType() {
         return messageType;

--- a/jpo-geojsonconverter/src/main/resources/schemas/processed-map.schema.json
+++ b/jpo-geojsonconverter/src/main/resources/schemas/processed-map.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://raw.githubusercontent.com/usdot-jpo-ode/jpo-geojsonconverter/develop/jpo-geojsonconverter/src/main/resources/schemas/processed-map.schema.json",
+    "$id": "processed-map-schema-v1",
     "type": "object",
     "description": "MAP object containing both FeatureCollections for lane data and another for connecting lane geometry for a single intersection and shared properties",
     "properties": {

--- a/jpo-geojsonconverter/src/main/resources/schemas/processed-map.schema.json
+++ b/jpo-geojsonconverter/src/main/resources/schemas/processed-map.schema.json
@@ -152,6 +152,10 @@
         "MapProperties": {
             "type": "object",
             "properties": {
+                "schemaVersion": {
+                    "const": 1,
+                    "type": "integer"
+                },
                 "messageType": {
                     "type": "string",
                     "const": "MAP"

--- a/jpo-geojsonconverter/src/main/resources/schemas/processed-map.schema.json
+++ b/jpo-geojsonconverter/src/main/resources/schemas/processed-map.schema.json
@@ -153,8 +153,8 @@
             "type": "object",
             "properties": {
                 "schemaVersion": {
-                    "const": 1,
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": -1
                 },
                 "messageType": {
                     "type": "string",

--- a/jpo-geojsonconverter/src/main/resources/schemas/processed-spat.schema.json
+++ b/jpo-geojsonconverter/src/main/resources/schemas/processed-spat.schema.json
@@ -3,6 +3,10 @@
     "$id": "https://raw.githubusercontent.com/usdot-jpo-ode/jpo-geojsonconverter/develop/jpo-geojsonconverter/src/main/resources/schemas/processed-spat.schema.json",
     "type": "object",
     "properties": {
+        "schemaVersion": {
+            "const": 1,
+            "type": "integer"
+        },
         "messageType": {
             "type": "string",
             "const": "SPAT"

--- a/jpo-geojsonconverter/src/main/resources/schemas/processed-spat.schema.json
+++ b/jpo-geojsonconverter/src/main/resources/schemas/processed-spat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "https://raw.githubusercontent.com/usdot-jpo-ode/jpo-geojsonconverter/develop/jpo-geojsonconverter/src/main/resources/schemas/processed-spat.schema.json",
+    "$id": "processed-spat-schema-v1",
     "type": "object",
     "properties": {
         "schemaVersion": {

--- a/jpo-geojsonconverter/src/main/resources/schemas/processed-spat.schema.json
+++ b/jpo-geojsonconverter/src/main/resources/schemas/processed-spat.schema.json
@@ -4,8 +4,8 @@
     "type": "object",
     "properties": {
         "schemaVersion": {
-            "const": 1,
-            "type": "integer"
+            "type": "integer",
+            "minimum": -1
         },
         "messageType": {
             "type": "string",

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/map/MapSharedPropertiesTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/map/MapSharedPropertiesTest.java
@@ -18,6 +18,13 @@ import us.dot.its.jpo.ode.plugin.j2735.OdePosition3D;
 
 public class MapSharedPropertiesTest {
     @Test
+    public void testSchemaVersion() {
+        Integer expectedSchemaVersion = 1;
+        MapSharedProperties mapSharedProperties = new MapSharedProperties();
+        assertEquals(expectedSchemaVersion, mapSharedProperties.getSchemaVersion());
+    }
+
+    @Test
     public void testMessageType() {
         String expectedMessageType = "type";
         MapSharedProperties mapSharedProperties = new MapSharedProperties();

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/map/MapSharedPropertiesTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/pojos/geojson/map/MapSharedPropertiesTest.java
@@ -19,8 +19,9 @@ import us.dot.its.jpo.ode.plugin.j2735.OdePosition3D;
 public class MapSharedPropertiesTest {
     @Test
     public void testSchemaVersion() {
-        Integer expectedSchemaVersion = 1;
+        int expectedSchemaVersion = 1;
         MapSharedProperties mapSharedProperties = new MapSharedProperties();
+        mapSharedProperties.setSchemaVersion(1);
         assertEquals(expectedSchemaVersion, mapSharedProperties.getSchemaVersion());
     }
 

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/pojos/spat/ProcessedSpatTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/pojos/spat/ProcessedSpatTest.java
@@ -16,7 +16,8 @@ public class ProcessedSpatTest {
     public void testGettersSetters() {
         ProcessedSpat object = new ProcessedSpat();
 
-        Integer versionResponse = object.getSchemaVersion();
+        object.setSchemaVersion(1);
+        int versionResponse = object.getSchemaVersion();
         assertEquals(versionResponse, 1);
 
         object.setMessageType("type");

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/pojos/spat/ProcessedSpatTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/pojos/spat/ProcessedSpatTest.java
@@ -16,6 +16,9 @@ public class ProcessedSpatTest {
     public void testGettersSetters() {
         ProcessedSpat object = new ProcessedSpat();
 
+        Integer versionResponse = object.getSchemaVersion();
+        assertEquals(versionResponse, 1);
+
         object.setMessageType("type");
         String typeResponse = object.getMessageType();
         assertEquals(typeResponse, "type");


### PR DESCRIPTION
This adds a schema version to the ProcessedMap and ProcessedSpat message types. Since this is the first iteration with a schema version they have been set to version 1.

This has been added as a request by CDOT and also a general means of tracking when schema changes are made in the future.