### PR TITLE
Jackson Allow Unknown Properties

### DIFF
--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/DateJsonMapper.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/DateJsonMapper.java
@@ -1,6 +1,7 @@
 package us.dot.its.jpo.geojsonconverter;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -13,6 +14,7 @@ public class DateJsonMapper {
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         objectMapper.setSerializationInclusion(Include.NON_NULL);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     public static ObjectMapper getInstance() {


### PR DESCRIPTION
Allows Jackson's Object Mapper to not fail when there are extra unknown properties. This change will prevent errors when doing schema updates from the ODE.