### PR TITLE
CDOT 2025 Q2 Release Changes

### DIFF
--- a/.azure/README.md
+++ b/.azure/README.md
@@ -1,0 +1,43 @@
+# Azure Pipeline Configuration
+
+This directory contains the Azure DevOps pipeline configuration for the JPO GeoJSON Converter project.
+
+## Overview
+
+The pipeline configuration in `azure-pipelines.yml` is primarily used for Continuous Integration (CI) in the CDOT-CV fork of the JPO GeoJSON Converter project. It serves as the first step in a two-stage process:
+
+1. **Build Pipeline (this configuration)**
+   - Triggers on changes to the `develop` branch
+   - Monitors specific project directories for changes:
+     - `jpo-geojsonconverter/*`
+   - Copies all source files to the artifact staging directory
+   - Publishes the source code as an artifact named 'jpo-geojsonconverter'
+
+2. **Release Pipeline (configured in Azure DevOps)**
+   - Uses the published artifact from the build pipeline
+   - Handles Docker image building and deployment
+   - Configuration is managed through the Azure DevOps web interface
+
+## Pipeline Trigger
+
+The pipeline automatically triggers when:
+
+- Changes are pushed to the `develop` branch
+- Changes occur in any of the monitored project directories
+
+## Pipeline Steps
+
+1. **Copy Files**
+   - Copies project files to the artifact staging directory
+   - Excludes certain files/directories by default:
+     - `.git` directories
+     - `docs` directories
+     - Markdown (`.md`) files
+
+2. **Publish Artifact**
+   - Creates an artifact named 'jpo-geojsonconverter'
+   - Makes the source code available for the release pipeline
+
+## Note
+
+The actual Docker build process and deployment steps are configured in the Azure DevOps release pipeline, which is separate from this build pipeline configuration. The release pipeline picks up the artifact produced by this build pipeline and performs the necessary build and deployment steps.

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -1,0 +1,30 @@
+# Azure pipeline used to trigger builds of the JPO Geojson Converter project
+# This pipeline is primarily used for CI in the CDOT-CV fork
+
+trigger:
+  branches:
+    include:
+      - develop
+  paths:
+    include:
+      - "jpo-geojsonconverter/*"
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - task: CopyFiles@2
+    inputs:
+      SourceFolder: "$(Build.SourcesDirectory)"
+      Contents: |
+        **
+        !**/docs/**
+        !**/*.md
+      TargetFolder: "$(Build.ArtifactStagingDirectory)"
+
+  # Publish the artifacts directory for consumption in publish pipeline
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: "$(Build.ArtifactStagingDirectory)"
+      ArtifactName: "jpo-geojsonconverter"
+      publishLocation: "Container"

--- a/.github/workflows/artifact-publish.yml
+++ b/.github/workflows/artifact-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'jpo-geojsonconverter-*'
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,7 +1,19 @@
 JPO GeoJSON Converter Release Notes
 ----------------------------
 
-Version 2.0.0
+Version 2.2.0
+----------------------------------------
+
+### **Summary**
+This release includes compatibility upgrades for the jpo-ode 4.1.0 version.
+
+Enhancements in this release:
+- [CDOT PR 13](https://github.com/CDOT-CV/jpo-geojsonconverter/pull/13): Update gjc to work with latest version of the jpo-ode 4.1.0
+- [CDOT PR 12](https://github.com/CDOT-CV/jpo-geojsonconverter/pull/12): Adding Git history to CI Pipelines
+- [CDOT PR 10](https://github.com/CDOT-CV/jpo-geojsonconverter/pull/10): Setting up CI with Azure Pipelines configuration.
+- [USDOT PR 92](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/pull/92): Processed PSM and Schema Generation
+
+Version 2.0.0 + 2.1.0
 ----------------------------------------
 
 ### **Summary**

--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -9,15 +9,21 @@
         <version>3.1.3</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
+
+    <scm>
+        <developerConnection>scm:git:https://github.com/usdot-jpo-ode/jpo-geojsonconverter.git</developerConnection>
+        <tag>jpo-geojsonconverter-usdot-2.2.0</tag>
+    </scm>
+
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-geojsonconverter</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
     <name>jpo-geojsonconverter</name>
     <description>J2735 message to GeoJSON converter for US DOT ITS JPO ODE</description>
     <properties>
         <java.version>21</java.version>
-        <jpoode.version>4.0.0</jpoode.version>
+        <jpoode.version>4.1.1</jpoode.version>
         <sonar.organization>usdot-jpo-ode</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.exclusions>src/main/**/GeoJsonConverterApplication.java,

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/GeoJsonConverterProperties.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/GeoJsonConverterProperties.java
@@ -30,7 +30,6 @@ import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.processor.LogAndSkipOnInvalidTimestamp;
 
 import us.dot.its.jpo.geojsonconverter.pojos.GeometryOutputMode;
-import us.dot.its.jpo.ode.util.CommonUtils;
 
 @ConfigurationProperties("geojsonconverter")
 public class GeoJsonConverterProperties implements EnvironmentAware {
@@ -73,7 +72,7 @@ public class GeoJsonConverterProperties implements EnvironmentAware {
     @PostConstruct
     public void initialize() {
         if (kafkaBrokers == null) {
-            String dockerIp = CommonUtils.getEnvironmentVariable("DOCKER_HOST_IP");
+            String dockerIp = getEnvironmentVariable("DOCKER_HOST_IP");
 
             if (dockerIp == null) {
                 logger.warn(
@@ -85,12 +84,12 @@ public class GeoJsonConverterProperties implements EnvironmentAware {
                     kafkaBrokers);
         }
 
-        String kafkaType = CommonUtils.getEnvironmentVariable("KAFKA_TYPE");
+        String kafkaType = getEnvironmentVariable("KAFKA_TYPE");
         if (kafkaType != null) {
             confluentCloudEnabled = kafkaType.equals("CONFLUENT");
             if (confluentCloudEnabled) {
-                confluentKey = CommonUtils.getEnvironmentVariable("CONFLUENT_KEY");
-                confluentSecret = CommonUtils.getEnvironmentVariable("CONFLUENT_SECRET");
+                confluentKey = getEnvironmentVariable("CONFLUENT_KEY");
+                confluentSecret = getEnvironmentVariable("CONFLUENT_SECRET");
             }
         }
     }
@@ -263,5 +262,13 @@ public class GeoJsonConverterProperties implements EnvironmentAware {
 
     public int getKafkaLingerMs() {
         return lingerMs;
+    }
+
+    private static String getEnvironmentVariable(String variableName) {
+        String value = System.getenv(variableName);
+        if (value == null || value.equals("")) {
+            System.out.println("Something went wrong retrieving the environment variable " + variableName);
+        }
+        return value;
     }
 }

--- a/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/GeoJsonConverterPropertiesTest.java
+++ b/jpo-geojsonconverter/src/test/java/us/dot/its/jpo/geojsonconverter/GeoJsonConverterPropertiesTest.java
@@ -11,7 +11,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.info.BuildProperties;
 
-import us.dot.its.jpo.ode.util.CommonUtils;
 
 
 public class GeoJsonConverterPropertiesTest {
@@ -19,7 +18,6 @@ public class GeoJsonConverterPropertiesTest {
     
     GeoJsonConverterProperties testGeoJsonConverterProperties;
     BuildProperties mockBuildProperties;
-    CommonUtils capturingCommonUtils;
 
     @Before
     public void setup() {

--- a/sample.env
+++ b/sample.env
@@ -21,7 +21,6 @@ DOCKER_HOST_IP=
 
 # GitHub properties for pulling the latest version of the JPO-ODE at build time
 # NOTE: These variables are only required for building the geojson-converter image, not for running the image
-MAVEN_GITHUB_TOKEN_NAME=
 MAVEN_GITHUB_TOKEN=
 MAVEN_GITHUB_ORG=usdot-jpo-ode
 


### PR DESCRIPTION
This includes all of the 2025 Q2 release changes from the CDOT fork but this pull request is intended to serve as a means to allow the CI to run correctly and show that it actually does work as is.

Preparations for the 2025 Q2 release

Enhancements in this release:
- [CDOT PR 13](https://github.com/CDOT-CV/jpo-geojsonconverter/pull/13): Update gjc to work with latest version of the jpo-ode 4.1.0
- [CDOT PR 12](https://github.com/CDOT-CV/jpo-geojsonconverter/pull/12): Adding Git history to CI Pipelines
- [CDOT PR 10](https://github.com/CDOT-CV/jpo-geojsonconverter/pull/10): Setting up CI with Azure Pipelines configuration.
- [USDOT PR 92](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/pull/92): Processed PSM and Schema Generation