### PR TITLE
Hotfix for RTCM Validation

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -6,10 +6,9 @@ Version 3.2.1 - HOTFIX
 
 ### **Summary**
 
-Hotfix that fixes RTCM validation using the incorrect json schema.
+Fixes RTCM validation using the incorrect json schema.
 
-- TBD: Link to PR
-
+- [Changes in hotfix 3.2.1](https://github.com/usdot-jpo-ode/jpo-geojsonconverter/compare/master...neaeraconsulting:jpo-geojsonconverter:hotfix/2025-12-29)
 
 Version 3.2.0
 ----------------------------------------

--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,6 +1,16 @@
 JPO GeoJSON Converter Release Notes
 ----------------------------
 
+Version 3.2.1 - HOTFIX
+----------------------------------------
+
+### **Summary**
+
+Hotfix that fixes RTCM validation using the incorrect json schema.
+
+- TBD: Link to PR
+
+
 Version 3.2.0
 ----------------------------------------
 

--- a/jpo-geojsonconverter/pom.xml
+++ b/jpo-geojsonconverter/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>usdot.jpo.ode</groupId>
     <artifactId>jpo-geojsonconverter</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1</version>
     <packaging>jar</packaging>
     <name>jpo-geojsonconverter</name>
     <description>J2735 message to GeoJSON converter for US DOT ITS JPO ODE</description>

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/RTCMJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/RTCMJsonValidator.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 public class RTCMJsonValidator extends AbstractJsonValidator {
 
     public RTCMJsonValidator() {
-        super("classpath:schemas/srm.schema.json");
+        super("classpath:schemas/rtcm.schema.json");
     }
 
     /**

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/RTCMJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/RTCMJsonValidator.java
@@ -1,7 +1,5 @@
 package us.dot.its.jpo.geojsonconverter.validator;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 
 /**

--- a/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/RTCMJsonValidator.java
+++ b/jpo-geojsonconverter/src/main/java/us/dot/its/jpo/geojsonconverter/validator/RTCMJsonValidator.java
@@ -5,7 +5,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
 
 /**
- * JSON validator for RTCM messasges.
+ * JSON validator for RTCM messages.
  * Validates J2735 requirements and ODE metadata.
  */
 @Service


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Fixes the RTCM validation to use the correct RTCM json schema.

Increments the version number to 3.2.1 in the pom.

## Related GitHub Issue

N/A

## Related Jira Key

N/A

## Motivation and Context

The current release of the GeoJSON Converter, version 3.1.0, has a bug where it uses the wrong json schema to validate RTCM messages, which causes incorrect validation messages to be produced in ProcessedRtcms.

## How Has This Been Tested?

This was tested by running the ODE, the GeoJSON Converter, and Conflict Monitor apps in Docker and verifying that this integration test succeeds (no incorrect validation messages appear in the ProcessedRtcm messages):

https://github.com/neaeraconsulting/jpo-conflictmonitor/wiki/Test-RTCM-Minimum-Data-Events

and verifying that all existing unit tests in the GeoJSON Converter pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. - note added to Release notes
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes. - integration test in CIMMS
- [x] All new and existing tests passed.
